### PR TITLE
[WIP] Tests over SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,39 @@
                     ],
                     "default": null,
                     "description": "A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'"
+                },
+                "better-phpunit.ssh.enable": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Run tests over SSH"
+                },
+                "better-phpunit.ssh.user": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "The user to connect as when running test via SSH"
+                },
+                "better-phpunit.ssh.host": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "The hostname to use when running tests via SSH"
+                },
+                "better-phpunit.ssh.port": {
+                    "type": [
+                        "integer"
+                    ],
+                    "default": 22,
+                    "description": "The port to use when running tests via SSH"
+                },
+                "better-phpunit.ssh.paths": {
+                    "type": "object",
+                    "default": {},
+                    "description": "The SSH path map. Keys are local (host) paths and values are remote (guest) paths."
                 }
             }
         },

--- a/src/command-instance.js
+++ b/src/command-instance.js
@@ -1,6 +1,7 @@
 const findUp = require('find-up');
 const vscode = require('vscode');
 const path = require('path');
+const SSH = require("./ssh");
 
 module.exports = class CommandInstance {
     constructor() {
@@ -12,6 +13,12 @@ module.exports = class CommandInstance {
             || this.findExecutablePath();
 
         this.shellCommand = `${this.executablePath} ${this.fileName} ${this.filterString()}${this.commandSuffix()}`;
+
+        this.ssh = new SSH();
+
+        this.fileName = this.ssh.remapLocalPath(this.fileName)
+        this.executablePath = this.ssh.remapLocalPath(this.executablePath)
+        this.shellCommand = this.ssh.wrapCommand(this.shellCommand)
     }
 
     runEntireSuite() {

--- a/src/ssh.js
+++ b/src/ssh.js
@@ -1,0 +1,51 @@
+const vscode = require('vscode');
+
+module.exports = class SSH {
+    constructor() {
+        this.config = vscode.workspace.getConfiguration("better-phpunit")
+    }
+
+    get enabled() {
+        return this.config.get("ssh.enable")
+    }
+    
+    get paths() {
+        return this.enabled
+            ? this.config.get("ssh.paths")
+            : {}
+    }
+
+    get isRunningOnWindows() {
+        return /^win/.test(process.platform)
+    }
+
+    get binary() {
+        if (this.isRunningOnWindows) {
+            return "putty -ssh"
+        }
+
+        return "ssh"
+    }
+
+    remapLocalPath(path) {
+        for (const [localPath, remotePath] of Object.entries(this.paths)) {
+            if (path.startsWith(localPath)) {
+                return path.replace(localPath, remotePath)
+            }
+        }
+
+        return path
+    }
+
+    wrapCommand(command) {
+        if (! this.enabled) {
+            return command
+        }
+
+        const user = this.config.get("ssh.user")
+        const port = this.config.get("ssh.port")
+        const host = this.config.get("ssh.host")
+
+        return `${this.binary} -tt -p${port} ${user}@${host} "${command}"`
+    }
+}

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -20,6 +20,7 @@ describe("Better PHPUnit Test Suite", function () {
         // This allows us to test config options in tests and not harm other tests.
         await vscode.workspace.getConfiguration('better-phpunit').update('commandSuffix', null);
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
     });
 
     afterEach(async () => {
@@ -27,6 +28,7 @@ describe("Better PHPUnit Test Suite", function () {
         // This allows us to test config options in tests and not harm other tests.
         await vscode.workspace.getConfiguration('better-phpunit').update('commandSuffix', null);
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
     });
 
     it("Run file outside of method", async () => {

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -31,7 +31,7 @@ describe("SSH Tests", function () {
         Object.defineProperty(process, "platform", { value: this.originalPlatform })
 
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.paths", {})
-        })
+    })
 
     it("Commands are not wrapped when SSH is disabled", async function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false)
@@ -44,6 +44,11 @@ describe("SSH Tests", function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.user", "auser")
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.host", "ahost")
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.port", "2222")
+
+        // This test _sometimes_ fails. It might be because
+        // the config file isn't written to quickly enough
+        // Therefore we'll wait just in case
+        await timeout(250, () => { });
 
         assert.equal("ssh -tt -p2222 auser@ahost \"foo\"", (new SSH).wrapCommand("foo"))
     });
@@ -72,7 +77,7 @@ describe("SSH Tests", function () {
         // This test _sometimes_ fails. It might be because
         // the config file isn't written to quickly enough
         // Therefore we'll wait just in case
-        await timeout(500, () => {});
+        await timeout(250, () => {});
 
         assert.equal("/some/remote/path", (new SSH).remapLocalPath("/some/local/path"))
         assert.equal("/some/other_remote/path", (new SSH).remapLocalPath("/some/other_local/path"))

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+const vscode = require('vscode');
+const SSH = require('../src/ssh');
+const waitToAssertInSeconds = 1;
+
+// This is a little helper function to promisify setTimeout, so we can "await" setTimeout.
+function timeout(seconds, callback) {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            callback();
+            resolve();
+        }, seconds * waitToAssertInSeconds);
+    });
+}
+
+// I'd love for this to be SSH integration tests
+// Hwoever, that would take a fair amount of setup
+describe("SSH Tests", function () {
+    let originalPlatform
+
+    beforeEach(async () => {
+        this.originalPlatform = process.platform
+
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.paths", {
+            "/some/local/path": "/some/remote/path",
+            "/some/other_local/path": "/some/other_remote/path",
+        })
+    })
+
+    afterEach(async () => {
+        Object.defineProperty(process, "platform", { value: this.originalPlatform })
+
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.paths", {})
+        })
+
+    it("Commands are not wrapped when SSH is disabled", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false)
+
+        assert.equal("foo", (new SSH).wrapCommand("foo"))
+    });
+
+    it("Commands are wrapped when SSH is enabled", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", true)
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.user", "auser")
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.host", "ahost")
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.port", "2222")
+
+        assert.equal("ssh -tt -p2222 auser@ahost \"foo\"", (new SSH).wrapCommand("foo"))
+    });
+    
+    it("On Windows commands are wrapped with putty", async function () {
+        Object.defineProperty(process, "platform", { value: "win32" })
+
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", true)
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.user", "auser")
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.host", "ahost")
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.port", "2222")
+
+        assert.equal("putty -ssh -tt -p2222 auser@ahost \"foo\"", (new SSH).wrapCommand("foo"))
+    });
+
+    it("Paths are not convereted when SSH is disabled", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false)
+
+        assert.equal("/some/local/path", (new SSH).remapLocalPath("/some/local/path"))
+        assert.equal("/some/other_local/path", (new SSH).remapLocalPath("/some/other_local/path"))
+    });
+
+    it("Paths are converted when SSH is enabled", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", true)
+
+        // This test _sometimes_ fails. It might be because
+        // the config file isn't written to quickly enough
+        // Therefore we'll wait just in case
+        await timeout(500, () => {});
+
+        assert.equal("/some/remote/path", (new SSH).remapLocalPath("/some/local/path"))
+        assert.equal("/some/other_remote/path", (new SSH).remapLocalPath("/some/other_local/path"))
+    });
+});


### PR DESCRIPTION
Thanks for the extension!

I run a vagrant box (via Homestead) and I have tests that must be run over SSH so I figured I'd help out with that. Still a WIP as there are things that need to be done.

- [ ] Ability to specify key pair
- [ ] Command: "Run Tests Locally"
- [ ] Command: "Run Tests over SSH"
- [x] Tests
- [ ] Documentation

I'm considering adding multi-host support but it's not 100% necessary at the moment so if I do it'll likely be a separate PR.