### PR TITLE
Fix SSH path remapping

### DIFF
--- a/src/command-instance.js
+++ b/src/command-instance.js
@@ -22,6 +22,7 @@ module.exports = class CommandInstance {
 
     runEntireSuite() {
         this.shellCommand = `${this.executablePath}${this.commandSuffix()}`;
+        this.shellCommand = this.ssh.wrapCommand(this.shellCommand)
 
         return this;
     }

--- a/src/command-instance.js
+++ b/src/command-instance.js
@@ -5,19 +5,18 @@ const SSH = require("./ssh");
 
 module.exports = class CommandInstance {
     constructor() {
+        this.ssh = new SSH();
+
         this.fileName = this.normalizePath(vscode.window.activeTextEditor.document.fileName);
+        this.fileName = this.ssh.remapLocalPath(this.fileName)
 
         this.methodName = this.findMethodName();
 
         this.executablePath = vscode.workspace.getConfiguration('better-phpunit').get('phpunitBinary')
             || this.findExecutablePath();
+        this.executablePath = this.ssh.remapLocalPath(this.executablePath)
 
         this.shellCommand = `${this.executablePath} ${this.fileName} ${this.filterString()}${this.commandSuffix()}`;
-
-        this.ssh = new SSH();
-
-        this.fileName = this.ssh.remapLocalPath(this.fileName)
-        this.executablePath = this.ssh.remapLocalPath(this.executablePath)
         this.shellCommand = this.ssh.wrapCommand(this.shellCommand)
     }
 

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -64,7 +64,7 @@ describe("SSH Tests", function () {
         assert.equal("putty -ssh -tt -p2222 auser@ahost \"foo\"", (new SSH).wrapCommand("foo"));
     });
 
-    it("Paths are not convereted when SSH is disabled", async function () {
+    it("Paths are not converted when SSH is disabled", async function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
 
         assert.equal("/some/local/path", (new SSH).remapLocalPath("/some/local/path"));

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -84,7 +84,7 @@ describe("SSH Tests", function () {
 
     // FIXME: This uses an implementation detail but there's
     // currently no simple way to setup SSH integration tests
-    it.only("The correct SSH command is run when triggering Better PHPUnit", async function () {
+    it("The correct SSH command is run when triggering Better PHPUnit", async function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.paths", {
             "/Users/calebporzio/Documents/Code/sites/better-phpunit": "/some/remote/path",
         });


### PR DESCRIPTION
Oops.

Fixed with better tests to verify that it works.

You know, if fileName, executablePath, and shellCommand were getters it would remove code order dependency things like this. :)

Note: Mind running the whole test suite? I don't know how you run them because when I do the `vscode.workspace.rootPath` does not include `project-stub`