### PR TITLE
Allow configuration of SSH binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
                     "default": null,
                     "description": "A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'"
                 },
+                "better-phpunit.ssh.binary": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "The path (and flags) to an SSH-compatible binary. If null it will use SSH on *nix and Putty on Windows."
+                },
                 "better-phpunit.ssh.enable": {
                     "type": "boolean",
                     "default": false,

--- a/src/ssh.js
+++ b/src/ssh.js
@@ -20,6 +20,10 @@ module.exports = class SSH {
     }
 
     get binary() {
+        if (this.config.get("ssh.binary")) {
+            return this.config.get("ssh.binary");
+        }
+
         if (this.isRunningOnWindows) {
             return "putty -ssh";
         }

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -64,6 +64,16 @@ describe("SSH Tests", function () {
         assert.equal("putty -ssh -tt -p2222 auser@ahost \"foo\"", (new SSH).wrapCommand("foo"));
     });
 
+    it("On Custom SSH binaries are preferred over the defaults", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", true);
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.user", "auser");
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.host", "ahost");
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.port", "2222");
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.binary", "openssh");
+
+        assert.equal("openssh -tt -p2222 auser@ahost \"foo\"", (new SSH).wrapCommand("foo"));
+    });
+
     it("Paths are not convereted when SSH is disabled", async function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
 


### PR DESCRIPTION
Closes #26.

We can also make the default just "ssh" and require users on Windows to always configure their binary. Thoughts?