### PR TITLE
Support running test methods that use data providers

### DIFF
--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -28,7 +28,7 @@ module.exports = class PhpUnitCommand {
     }
 
     get filter() {
-        return this.method ? `--filter '^.*::${this.method}$'` : '';
+        return this.method ? `--filter '^.*::${this.method}( with data set .*)?$'` : '';
     }
 
     get suffix() {

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -127,7 +127,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                "/Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/vendor/bin/phpunit /Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/tests/SampleTest.php --filter '^.*::test_first$'"
+                "/Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/vendor/bin/phpunit /Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/tests/SampleTest.php --filter '^.*::test_first( with data set .*)?$'"
             );
         });
     });
@@ -140,7 +140,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                "/Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/vendor/bin/phpunit /Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/tests/SampleTest.php --filter '^.*::test_first$'"
+                "/Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/vendor/bin/phpunit /Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/tests/SampleTest.php --filter '^.*::test_first( with data set .*)?$'"
             );
         });
     });

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -48,7 +48,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            '/Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/vendor/bin/phpunit /Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/tests/SampleTest.php --filter \'^.*::test_first$\''
+            '/Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/vendor/bin/phpunit /Users/calebporzio/Documents/Code/sites/better-phpunit/test/project-stub/tests/SampleTest.php --filter \'^.*::test_first( with data set .*)?$\''
         );
     });
 
@@ -61,7 +61,7 @@ describe("SSH Tests", function () {
 
        assert.equal(
             extension.getGlobalCommandInstance().output,
-            'ssh -tt -p2222 auser@ahost "/some/remote/path/test/project-stub/vendor/bin/phpunit /some/remote/path/test/project-stub/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'ssh -tt -p2222 auser@ahost "/some/remote/path/test/project-stub/vendor/bin/phpunit /some/remote/path/test/project-stub/tests/SampleTest.php --filter \'^.*::test_first( with data set .*)?$\'"'
         );
     });
 
@@ -76,7 +76,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            'putty -ssh -tt -p2222 auser@ahost "/some/remote/path/test/project-stub/vendor/bin/phpunit /some/remote/path/test/project-stub/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'putty -ssh -tt -p2222 auser@ahost "/some/remote/path/test/project-stub/vendor/bin/phpunit /some/remote/path/test/project-stub/tests/SampleTest.php --filter \'^.*::test_first( with data set .*)?$\'"'
         );
     });
 });


### PR DESCRIPTION
When using data providers in PHPUnit you cannot run a single method because the regex specifies the method name then an ending anchor in the filter (ex: `^.*::testAdd$`)

Take this example from the PHPUnit documentation:
```php
/**
* @dataProvider additionProvider
*/
public function testAdd($a, $b, $expected)
{
    $this->assertEquals($expected, $a + $b);
}

public function additionProvider()
{
    return [
        [0, 0, 0],
        [0, 1, 1],
        [1, 0, 1],
    ];
}
```

Attempting to run the tests for `testAdd` will result in "No tests executed!" because the regex is `^.*::testAdd$`

I've adjusted the regex to _optionally_ match the PHPUnit data set specifier. Now the filter is written out like so `^.*::testAdd( with data set .*)?$`. I've verified that these changes work for normal and data-provided methods locally and when using SSH.

Should I add a method using data providers to the project stub test suite?