### PR TITLE
Adds PHPUnit XML dist support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "better-phpunit",
     "displayName": "Better PHPUnit",
     "description": "A better PHPUnit test runner",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "publisher": "calebporzio",
     "engines": {
         "vscode": "^1.17.0"

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -55,7 +55,7 @@ module.exports = class PhpUnitCommand {
 
     get subDirectory() {
         // find the closest phpunit.xml file in the project (for projects with multiple "vendor/bin/phpunit"s).
-        let phpunitDotXml = findUp.sync('phpunit.xml', { cwd: vscode.window.activeTextEditor.document.fileName });
+        let phpunitDotXml = findUp.sync(['phpunit.xml', 'phpunit.xml.dist'], { cwd: vscode.window.activeTextEditor.document.fileName });
 
         return path.dirname(phpunitDotXml) !== vscode.workspace.rootPath
             ? path.dirname(phpunitDotXml)


### PR DESCRIPTION
This PR adds support for `phpunit.xml.dist` file name in in addition to `phpunit.xml`. As outlined in the [PHPUnit documentation](https://phpunit.de/manual/current/en/organizing-tests.html#organizing-tests.xml-configuration) `phpunit.xml.dist` is one of two standard configuration file names.