### PR TITLE
Fix issues #35 and #42 (SSH on Windows)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
                         "integer"
                     ],
                     "default": 22,
-                    "description": "The port to use when running tests via SSH"
+                    "description": "The port to use when running tests via SSH.  Deprecated, set better-phpunit.options to '-p[port]' on Linux/Mac, and '-P [port]' on Windows."
                 },
                 "better-phpunit.ssh.paths": {
                     "type": "object",
@@ -104,6 +104,14 @@
                     ],
                     "default": null,
                     "description": "The path (and flags) to an SSH-compatible binary. If null it will use SSH on *nix and Putty on Windows."
+                },
+                "better-phpunit.ssh.options": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "Additional command line options to pass to ssh/putty/plink"
                 }
             }
         },

--- a/src/remote-phpunit-command.js
+++ b/src/remote-phpunit-command.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const PhpUnitCommand = require('./phpunit-command');
+const path = require('path');
 
 module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
     constructor(options) {
@@ -18,6 +19,12 @@ module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
 
     get output() {
         return this.wrapCommand(super.output);
+    }
+
+    get configuration() {
+        return this.subDirectory
+            ? ' --configuration ' + this.remapLocalPath(this._normalizePath(path.join(this.subDirectory, 'phpunit.xml')))
+            : '';
     }
 
     get paths() {
@@ -46,7 +53,11 @@ module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
         const user = this.config.get("ssh.user");
         const port = this.config.get("ssh.port");
         const host = this.config.get("ssh.host");
+        let options = this.config.get("ssh.options");
 
-        return `${this.sshBinary} -tt -p${port} ${user}@${host} "${command}"`;
+        if (!options)
+            options = `-tt -p${port}`;
+
+        return `${this.sshBinary} ${options} ${user}@${host} "${command}"`;
     }
 }


### PR DESCRIPTION
This calls `remapLocalPath()` for `phpunit.xml` so that it will correctly use a remote path rather than the local path.

It also changes the options available for SSH, allowing you to specify arbitrary command line parameters to the SSH executable.  This allows it to work on Windows, as Windows sets the port with '-P 22' where Linux uses '-p22'.  It also allows for additional options like SSH key file for logging in with certificate based authentication.