### PR TITLE
#42 Remote phpunit configuration parameter uses the correctly remapped path

### DIFF
--- a/src/remote-phpunit-command.js
+++ b/src/remote-phpunit-command.js
@@ -1,11 +1,18 @@
 const vscode = require('vscode');
 const PhpUnitCommand = require('./phpunit-command');
+const path = require('path');
 
 module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
     constructor(options) {
         super(options);
 
         this.config = vscode.workspace.getConfiguration("better-phpunit");
+    }
+
+    get configuration() {
+        return this.subDirectory
+            ? ` --configuration ${this.remapLocalPath(this._normalizePath(path.join(this.subDirectory, 'phpunit.xml')))}`
+            : '';
     }
 
     get file() {


### PR DESCRIPTION
When running unit tests remotely, the `--configuration` parameter uses the local path rather than the remote path.  This commit calls `remapLocalPath()` to fix it.