### PR TITLE
Disabled calls to terminal clear to fix send popup #46

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -49,12 +49,12 @@ async function runCommand(command) {
     vscode.window.activeTextEditor
         || vscode.window.showErrorMessage('Better PHPUnit: open a file to run this command');
 
-    await vscode.commands.executeCommand('workbench.action.terminal.clear');
+    //await vscode.commands.executeCommand('workbench.action.terminal.clear');
     await vscode.commands.executeCommand('workbench.action.tasks.runTask', 'phpunit: run');
 }
 
 async function runPreviousCommand() {
-    await vscode.commands.executeCommand('workbench.action.terminal.clear');
+    //await vscode.commands.executeCommand('workbench.action.terminal.clear');
     await vscode.commands.executeCommand('workbench.action.tasks.runTask', 'phpunit: run');
 }
 


### PR DESCRIPTION
A temp hack to fix the popup "Cannot read property 'send' of null" that occurs when running commands #46 .  This might have side-effects.