### PR TITLE
Adds option to disable all SSH options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-phpunit",
-    "version": "0.7.0",
+    "version": "0.8.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -11,9 +11,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "7.0.66",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.66.tgz",
-            "integrity": "sha512-W11u5kUNSX2+N6bJ7rPyLW4N98/xzrZg8apRoTwC0zbFjIie//oxgKAvqkQNQ97KVchB49ost74kgzoeDiE+Uw==",
+            "version": "7.0.69",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
+            "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
             "dev": true
         },
         "acorn": {
@@ -28,7 +28,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "3.3.0"
+                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
@@ -45,10 +45,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -105,7 +105,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -114,8 +114,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -148,7 +148,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -205,9 +205,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -216,11 +216,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -229,7 +229,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 }
             }
@@ -247,7 +247,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "block-stream": {
@@ -256,7 +256,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "brace-expansion": {
@@ -265,7 +265,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -275,9 +275,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -304,7 +304,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsites": {
@@ -325,9 +325,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -336,7 +336,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.2"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "supports-color": {
@@ -345,7 +345,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -368,7 +368,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -401,9 +401,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "co": {
@@ -433,7 +433,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -442,7 +442,7 @@
             "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
             "dev": true,
             "requires": {
-                "graceful-readlink": "1.0.1"
+                "graceful-readlink": ">= 1.0.0"
             }
         },
         "concat-map": {
@@ -457,10 +457,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "convert-source-map": {
@@ -481,9 +481,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "dashdash": {
@@ -492,7 +492,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "debug": {
@@ -510,7 +510,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "deep-is": {
@@ -525,13 +525,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "delayed-stream": {
@@ -552,7 +552,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "duplexer": {
@@ -567,10 +567,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -580,7 +580,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "end-of-stream": {
@@ -589,7 +589,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -604,44 +604,44 @@
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.4.1",
-                "concat-stream": "1.6.2",
-                "cross-spawn": "5.1.0",
-                "debug": "3.1.0",
-                "doctrine": "2.1.0",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "3.5.4",
-                "esquery": "1.0.1",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.7.0",
-                "ignore": "3.3.10",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.12.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "regexpp": "1.1.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.0",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
+                "ajv": "^5.3.0",
+                "babel-code-frame": "^6.22.0",
+                "chalk": "^2.1.0",
+                "concat-stream": "^1.6.0",
+                "cross-spawn": "^5.1.0",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^3.7.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^3.5.4",
+                "esquery": "^1.0.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.0.1",
+                "ignore": "^3.3.3",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^3.0.6",
+                "is-resolvable": "^1.0.0",
+                "js-yaml": "^3.9.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^1.0.1",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.3.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "~2.0.1",
                 "table": "4.0.2",
-                "text-table": "0.2.0"
+                "text-table": "~0.2.0"
             }
         },
         "eslint-scope": {
@@ -650,8 +650,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-visitor-keys": {
@@ -666,8 +666,8 @@
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
-                "acorn": "5.7.1",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^5.5.0",
+                "acorn-jsx": "^3.0.0"
             }
         },
         "esprima": {
@@ -682,7 +682,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -691,7 +691,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -712,13 +712,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -727,7 +727,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -736,7 +736,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "extend": {
@@ -751,7 +751,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             }
         },
         "external-editor": {
@@ -760,9 +760,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.23",
-                "tmp": "0.0.33"
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
             }
         },
         "extglob": {
@@ -771,7 +771,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -812,7 +812,7 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "figures": {
@@ -821,7 +821,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -830,8 +830,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "filename-regex": {
@@ -846,11 +846,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "find-up": {
@@ -858,7 +858,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "first-chunk-stream": {
@@ -873,10 +873,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "for-in": {
@@ -891,7 +891,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -906,9 +906,9 @@
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -929,10 +929,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "functional-red-black-tree": {
@@ -947,7 +947,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -956,12 +956,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -970,8 +970,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -980,7 +980,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -995,7 +995,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1006,8 +1006,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -1016,14 +1016,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -1032,11 +1032,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -1051,10 +1051,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1069,8 +1069,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -1087,12 +1087,12 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "graceful-fs": {
@@ -1119,9 +1119,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -1130,9 +1130,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -1141,8 +1141,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -1157,10 +1157,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1175,8 +1175,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -1187,11 +1187,11 @@
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.87.0",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0"
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -1212,12 +1212,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1228,11 +1228,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -1253,8 +1253,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1266,10 +1266,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-untar": {
@@ -1278,11 +1278,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1303,8 +1303,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1316,13 +1316,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.2",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -1343,7 +1343,7 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "vinyl": {
@@ -1352,12 +1352,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1374,8 +1374,8 @@
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -1384,7 +1384,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -1405,9 +1405,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
@@ -1416,7 +1416,7 @@
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ignore": {
@@ -1437,8 +1437,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1453,20 +1453,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.10",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             }
         },
         "is": {
@@ -1493,7 +1493,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -1520,7 +1520,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-number": {
@@ -1529,7 +1529,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1538,7 +1538,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1561,7 +1561,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -1570,7 +1570,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-posix-bracket": {
@@ -1660,8 +1660,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -1689,7 +1689,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stable-stringify-without-jsonify": {
@@ -1740,7 +1740,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "levn": {
@@ -1749,8 +1749,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "locate-path": {
@@ -1758,8 +1758,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -1774,8 +1774,8 @@
             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash.keys": "3.1.2"
+                "lodash._basecopy": "^3.0.0",
+                "lodash.keys": "^3.0.0"
             }
         },
         "lodash._basecopy": {
@@ -1808,9 +1808,9 @@
             "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
             "dev": true,
             "requires": {
-                "lodash._baseassign": "3.2.0",
-                "lodash._basecreate": "3.0.3",
-                "lodash._isiterateecall": "3.0.9"
+                "lodash._baseassign": "^3.0.0",
+                "lodash._basecreate": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -1837,9 +1837,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lru-cache": {
@@ -1848,8 +1848,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "map-stream": {
@@ -1870,7 +1870,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -1879,19 +1879,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1900,7 +1900,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -1915,7 +1915,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -1924,7 +1924,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1941,7 +1941,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "mimic-fn": {
@@ -1956,7 +1956,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -2009,12 +2009,12 @@
                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-flag": {
@@ -2029,7 +2029,7 @@
                     "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -2046,10 +2046,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "mute-stream": {
@@ -2070,7 +2070,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-path": {
@@ -2079,7 +2079,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "oauth-sign": {
@@ -2100,8 +2100,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "once": {
@@ -2110,7 +2110,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -2119,7 +2119,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "optionator": {
@@ -2128,12 +2128,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "ordered-read-streams": {
@@ -2142,8 +2142,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.6"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "os-tmpdir": {
@@ -2162,7 +2162,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "1.1.0"
+                "p-limit": "^1.1.0"
             }
         },
         "parse-glob": {
@@ -2171,10 +2171,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -2189,7 +2189,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2223,7 +2223,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -2256,7 +2256,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -2265,11 +2265,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "pluralize": {
@@ -2332,7 +2332,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -2341,9 +2341,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -2366,13 +2366,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regex-cache": {
@@ -2381,7 +2381,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regexpp": {
@@ -2420,26 +2420,26 @@
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             }
         },
         "require-uncached": {
@@ -2448,8 +2448,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "requires-port": {
@@ -2470,8 +2470,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "rimraf": {
@@ -2480,7 +2480,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "run-async": {
@@ -2489,7 +2489,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rx-lite": {
@@ -2504,7 +2504,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "4.0.8"
+                "rx-lite": "*"
             }
         },
         "safe-buffer": {
@@ -2531,7 +2531,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -2552,7 +2552,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "source-map": {
@@ -2567,8 +2567,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.0",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "split": {
@@ -2577,7 +2577,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sprintf-js": {
@@ -2592,15 +2592,15 @@
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -2615,7 +2615,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -2630,7 +2630,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -2645,8 +2645,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string_decoder": {
@@ -2655,7 +2655,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -2664,7 +2664,7 @@
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2681,7 +2681,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -2690,8 +2690,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-json-comments": {
@@ -2712,12 +2712,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
+                "ajv": "^5.2.3",
+                "ajv-keywords": "^2.1.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "tar": {
@@ -2726,9 +2726,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "text-table": {
@@ -2749,8 +2749,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -2759,8 +2759,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "tmp": {
@@ -2769,7 +2769,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "to-absolute-glob": {
@@ -2778,7 +2778,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2787,7 +2787,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -2798,7 +2798,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tunnel-agent": {
@@ -2807,7 +2807,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -2823,7 +2823,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "typedarray": {
@@ -2844,8 +2844,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "url-parse": {
@@ -2854,8 +2854,8 @@
             "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
             "dev": true,
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -2882,9 +2882,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -2893,8 +2893,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
@@ -2903,23 +2903,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -2940,8 +2940,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2953,8 +2953,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
         "vscode": {
@@ -2963,20 +2963,20 @@
             "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.87.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.6",
-                "url-parse": "1.4.1",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "commander": {
@@ -3027,7 +3027,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -3038,7 +3038,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "wordwrap": {
@@ -3059,7 +3059,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "xtend": {
@@ -3080,8 +3080,8 @@
             "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.1.0"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
@@ -3090,7 +3090,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -161,12 +161,12 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "@types/mocha": "^2.2.42",
-        "@types/node": "^7.0.69",
-        "eslint": "^4.6.1",
-        "mocha": "^3.5.0",
         "typescript": "^2.5.2",
-        "vscode": "^1.1.5"
+        "vscode": "^1.1.5",
+        "mocha": "^3.5.0",
+        "eslint": "^4.6.1",
+        "@types/node": "^7.0.0",
+        "@types/mocha": "^2.2.42"
     },
     "dependencies": {
         "find-up": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
                     "default": null,
                     "description": "The path (and flags) to an SSH-compatible binary. If null it will use SSH on *nix and Putty on Windows."
                 },
+                "better-phpunit.ssh.disableAllOptions": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Do not include any config options in SSH command."
+                },
                 "better-phpunit.ssh.options": {
                     "type": [
                         "string",
@@ -136,7 +141,7 @@
                 ]
             }
         ],
-       "taskDefinitions": [
+        "taskDefinitions": [
             {
                 "type": "phpunit",
                 "required": [
@@ -156,12 +161,12 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript": "^2.5.2",
-        "vscode": "^1.1.5",
-        "mocha": "^3.5.0",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^7.0.69",
         "eslint": "^4.6.1",
-        "@types/node": "^7.0.0",
-        "@types/mocha": "^2.2.42"
+        "mocha": "^3.5.0",
+        "typescript": "^2.5.2",
+        "vscode": "^1.1.5"
     },
     "dependencies": {
         "find-up": "^2.1.0"

--- a/src/remote-phpunit-command.js
+++ b/src/remote-phpunit-command.js
@@ -54,10 +54,17 @@ module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
         const port = this.config.get("ssh.port");
         const host = this.config.get("ssh.host");
         let options = this.config.get("ssh.options");
+        let disableOptions = this.config.get("ssh.disableAllOptions");
+        console.log('disableOptions variable');
+        console.log(disableOptions);
+        let optionsString = '';
 
-        if (!options)
-            options = `-tt -p${port}`;
+        if (!disableOptions) {
+            if (!options)
+                options = `-tt -p${port}`;
+            optionsString = options + ` ${user}@${host} `;
+        }
 
-        return `${this.sshBinary} ${options} ${user}@${host} "${command}"`;
+        return `${this.sshBinary} ${optionsString}"${command}"`;
     }
 }

--- a/src/remote-phpunit-command.js
+++ b/src/remote-phpunit-command.js
@@ -55,13 +55,12 @@ module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
         const host = this.config.get("ssh.host");
         let options = this.config.get("ssh.options");
         let disableOptions = this.config.get("ssh.disableAllOptions");
-        console.log('disableOptions variable');
-        console.log(disableOptions);
         let optionsString = '';
 
         if (!disableOptions) {
-            if (!options)
+            if (!options) {
                 options = `-tt -p${port}`;
+            }
             optionsString = options + ` ${user}@${host} `;
         }
 

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -19,6 +19,7 @@ function timeout(seconds, callback) {
 describe("SSH Tests", function () {
     beforeEach(async () => {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", true);
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.disableAllOptions", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.user", "auser");
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.host", "ahost");
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.port", "2222");
@@ -31,6 +32,7 @@ describe("SSH Tests", function () {
 
     afterEach(async () => {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.disableAllOptions", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.user", "auser");
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.host", "ahost");
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.port", "2222");
@@ -45,7 +47,7 @@ describe("SSH Tests", function () {
         await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
         await vscode.commands.executeCommand('better-phpunit.run');
 
-        await timeout(waitToAssertInSeconds, () => {})
+        await timeout(waitToAssertInSeconds, () => { })
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
@@ -58,9 +60,9 @@ describe("SSH Tests", function () {
         await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
         await vscode.commands.executeCommand('better-phpunit.run');
 
-        await timeout(waitToAssertInSeconds, () => {})
+        await timeout(waitToAssertInSeconds, () => { })
 
-       assert.equal(
+        assert.equal(
             extension.getGlobalCommandInstance().output,
             'ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
         );
@@ -78,6 +80,21 @@ describe("SSH Tests", function () {
         assert.equal(
             extension.getGlobalCommandInstance().output,
             'putty -ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+        );
+    });
+
+    it("Can disable all ssh config options", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.disableAllOptions", true);
+
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run');
+
+        await timeout(waitToAssertInSeconds, () => { })
+
+        assert.equal(
+            extension.getGlobalCommandInstance().output,
+            'ssh "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
         );
     });
 });


### PR DESCRIPTION
When running PHPUnit tests within a Vagrant virtual machine, the standard SSH options (port, username, etc) placed by BetterPHPUnit conflicts with vagrant's requirements, i.e. `vagrant ssh -c ` and nothing else.

This adds a configuration option to remove all SSH options.