### PR TITLE
Add option runSuiteSuffix to 'run suite' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Config:
 {
     "better-phpunit.commandSuffix": null, // This string will be appended to the phpunit command, it's a great place to add flags like '--stop-on-failure'
     "better-phpunit.phpunitBinary": null // A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'
+    "better-phpunit.runSuites": null // Specify which suite(s) to run with the "run suite" command. Default is empty thus running all suites.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Config:
 {
     "better-phpunit.commandSuffix": null, // This string will be appended to the phpunit command, it's a great place to add flags like '--stop-on-failure'
     "better-phpunit.phpunitBinary": null // A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'
-    "better-phpunit.runSuites": null // Specify which suite(s) to run with the "run suite" command. Default is empty thus running all suites.
+    "better-phpunit.runSuiteSuffix": null // This string will be appended to the 'run suite' command, it's a great place to add flags like '--testsuite unit --coverage'
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,14 @@
                     "default": null,
                     "description": "Absolute path for the PHPUnit XML configuration file"
                 },
+                "better-phpunit.runSuites": {
+                    "type": [
+                            "string",
+                            "null"
+                    ],
+                    "default": null,
+                    "description": "Specify test suites to run with command 'run suite' as a comma-separated list of test suites"
+                },
                 "better-phpunit.ssh.enable": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -72,13 +72,13 @@
                     "default": null,
                     "description": "Absolute path for the PHPUnit XML configuration file"
                 },
-                "better-phpunit.runSuites": {
+                "better-phpunit.runSuiteSuffix": {
                     "type": [
                             "string",
                             "null"
                     ],
                     "default": null,
-                    "description": "Specify test suites to run with command 'run suite' as a comma-separated list of test suites"
+                    "description": "This string will be appended to the 'run suite' command, it's a great place to add flags like '--testsuite unit --coverage'"
                 },
                 "better-phpunit.ssh.enable": {
                     "type": "boolean",

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -16,12 +16,10 @@ module.exports = class PhpUnitCommand {
             return this.lastOutput;
         }
 
-        let runSuites = vscode.workspace.getConfiguration('better-phpunit').get('runSuites') || "";
-        if (runSuites) {
-            runSuites = ' --testsuite '.concat(runSuites.replace(/\s+/g,''));
-        }
+        let runSuiteSuffix = vscode.workspace.getConfiguration('better-phpunit').get('runSuiteSuffix');
+        runSuiteSuffix = runSuiteSuffix ? ' '.concat(runSuiteSuffix) : '';
         this.lastOutput = this.runFullSuite
-            ? `${this.binary}${runSuites}${this.suffix}`
+            ? `${this.binary}${runSuiteSuffix}${this.suffix}`
             : `${this.binary} ${this.file}${this.filter}${this.configuration}${this.suffix}`;
 
         return this.lastOutput;

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -16,8 +16,12 @@ module.exports = class PhpUnitCommand {
             return this.lastOutput;
         }
 
+        let runSuites = vscode.workspace.getConfiguration('better-phpunit').get('runSuites') || "";
+        if (runSuites) {
+            runSuites = ' --testsuite '.concat(runSuites.replace(/\s+/g,''));
+        }
         this.lastOutput = this.runFullSuite
-            ? `${this.binary}${this.suffix}`
+            ? `${this.binary}${runSuites}${this.suffix}`
             : `${this.binary} ${this.file}${this.filter}${this.configuration}${this.suffix}`;
 
         return this.lastOutput;

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -158,7 +158,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)$"
+                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)?$'"
             );
         });
     });
@@ -171,7 +171,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)$"
+                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)?$'"
             );
         });
     });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -22,7 +22,7 @@ describe("Better PHPUnit Test Suite", function () {
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
-        await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("runSuiteSuffix", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
     });
 
@@ -33,7 +33,7 @@ describe("Better PHPUnit Test Suite", function () {
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
-        await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("runSuiteSuffix", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
     });
 
@@ -191,8 +191,8 @@ describe("Better PHPUnit Test Suite", function () {
         });
     });
 
-    it("Run entire suite with specified suites", async () => {
-        await vscode.workspace.getConfiguration('better-phpunit').update('runSuites', 'unit, integration');
+    it("Run entire suite with specified suffix", async () => {
+        await vscode.workspace.getConfiguration('better-phpunit').update('runSuiteSuffix', '--testsuite unit --coverage');
         let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
         await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
         await vscode.commands.executeCommand('better-phpunit.run-suite')
@@ -200,7 +200,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit') + ' --testsuite unit,integration'
+                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit') + ' --testsuite unit --coverage'
             );
         });
     });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -22,6 +22,7 @@ describe("Better PHPUnit Test Suite", function () {
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
     });
 
@@ -32,6 +33,7 @@ describe("Better PHPUnit Test Suite", function () {
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
     });
 
@@ -185,6 +187,20 @@ describe("Better PHPUnit Test Suite", function () {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
                 path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit')
+            );
+        });
+    });
+
+    it("Run entire suite with specified suites", async () => {
+        await vscode.workspace.getConfiguration('better-phpunit').update('runSuites', 'unit, integration');
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run-suite')
+
+        await timeout(waitToAssertInSeconds, () => {
+            assert.equal(
+                extension.getGlobalCommandInstance().output,
+                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit') + ' --testsuite unit,integration'
             );
         });
     });

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -53,7 +53,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)$'"
+            path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)?$'"
         );
     });
 
@@ -66,7 +66,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            'ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
         );
     });
 
@@ -81,7 +81,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            'putty -ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'putty -ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
         );
     });
 
@@ -96,7 +96,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            'ssh "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'ssh "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
         );
     });
 });


### PR DESCRIPTION
Problem:
There might be times when you don't want to run all of your test suites but only specific suites, say for checking units and integration but not acceptance. This can be done via the command line switch "--testsuite <name,...>" of PHPUnit.

Solution:
Add a new option to specify which suites to run with the "run suite" command or run all of them if the option "runSuites" is empty (the default).

Remark:
This patch obviously had to include my previous one for fixing the extension tests.
