### PR TITLE
Add option to use codeception

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Config:
 {
     "better-phpunit.commandSuffix": null, // This string will be appended to the phpunit command, it's a great place to add flags like '--stop-on-failure'
     "better-phpunit.phpunitBinary": null // A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'
+    "better-phpunit.runSuites": null // Specify which suite(s) to run with the "run suite" command. Default is empty thus running all suites.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Config:
 {
     "better-phpunit.commandSuffix": null, // This string will be appended to the phpunit command, it's a great place to add flags like '--stop-on-failure'
     "better-phpunit.phpunitBinary": null // A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'
+    "better-phpunit.useCodeception": false // Switch to use Codeception instead of PHPUnit for testing. ATTENTION: You also have to specify the 'codecept' binary with the option "better-phpunit.phpunitBinary".
     "better-phpunit.runSuites": null // Specify which suite(s) to run with the "run suite" command. Default is empty thus running all suites.
 }
 ```

--- a/package.json
+++ b/package.json
@@ -72,6 +72,14 @@
                     "default": null,
                     "description": "Absolute path for the PHPUnit XML configuration file"
                 },
+                "better-phpunit.runSuites": {
+                    "type": [
+                            "string",
+                            "null"
+                    ],
+                    "default": null,
+                    "description": "Specify test suites to run with command 'run suite' as a comma-separated list of test suites"
+                },
                 "better-phpunit.ssh.enable": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
                     "default": null,
                     "description": "A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'"
                 },
+                "better-phpunit.useCodeception": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Run tests with Codeception instead of PHPUnit"
+                },
                 "better-phpunit.xmlConfigFilepath": {
                     "type": [
                         "string",

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -16,8 +16,12 @@ module.exports = class PhpUnitCommand {
             return this.lastOutput;
         }
 
+        let runSuites = vscode.workspace.getConfiguration('better-phpunit').get('runSuites') || "";
+        if (runSuites) {
+            runSuites = ' --testsuite '.concat(runSuites.replace(/\s+/g,''));
+        }
         this.lastOutput = this.runFullSuite
-            ? `${this.binary}${this.suffix}`
+            ? `${this.binary}${runSuites}${this.suffix}`
             : `${this.binary} ${this.file}${this.filter}${this.configuration}${this.suffix}`;
 
         return this.lastOutput;

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -18,7 +18,11 @@ module.exports = class PhpUnitCommand {
 
         let runSuites = vscode.workspace.getConfiguration('better-phpunit').get('runSuites') || "";
         if (runSuites) {
-            runSuites = ' --testsuite '.concat(runSuites.replace(/\s+/g,''));
+            if (vscode.workspace.getConfiguration('better-phpunit').get('useCodeception')) {
+                runSuites = ' '.concat(runSuites.replace(/\s+/g, ''));
+            } else {
+                runSuites = ' --testsuite '.concat(runSuites.replace(/\s+/g, ''));
+            }
         }
         this.lastOutput = this.runFullSuite
             ? `${this.binary}${runSuites}${this.suffix}`

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -60,8 +60,12 @@ module.exports = class PhpUnitCommand {
     }
 
     get binary() {
-        if (vscode.workspace.getConfiguration('better-phpunit').get('phpunitBinary')) {
-            return vscode.workspace.getConfiguration('better-phpunit').get('phpunitBinary')
+        let configuredBinary = vscode.workspace.getConfiguration('better-phpunit').get('phpunitBinary');
+        if (configuredBinary) {
+            if (vscode.workspace.getConfiguration('better-phpunit').get('useCodeception')) {
+                configuredBinary = configuredBinary.concat(' run');
+            }
+            return configuredBinary;
         }
 
         return this.subDirectory

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -191,7 +191,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + ":test_first"
+                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept run ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + ":test_first"
             );
         });
     });
@@ -250,7 +250,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept') + ' unit,integration'
+                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept run') + ' unit,integration'
             );
         });
     });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -158,7 +158,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)$"
+                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)?$'"
             );
         });
     });
@@ -171,7 +171,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)$"
+                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)?$'"
             );
         });
     });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -239,6 +239,22 @@ describe("Better PHPUnit Test Suite", function () {
         });
     });
 
+    it("Run entire suite with specified suites with Codeception", async () => {
+        await vscode.workspace.getConfiguration('better-phpunit').update('useCodeception', true);
+        await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', path.join(vscode.workspace.rootPath, '/vendor/bin/codecept'));
+        await vscode.workspace.getConfiguration('better-phpunit').update('runSuites', 'unit, integration');
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run-suite')
+
+        await timeout(waitToAssertInSeconds, () => {
+            assert.equal(
+                extension.getGlobalCommandInstance().output,
+                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept') + ' unit,integration'
+            );
+        });
+    });
+
     it("Run with commandSuffix config", async () => {
         await vscode.workspace.getConfiguration('better-phpunit').update('commandSuffix', '--foo=bar');
 

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -239,10 +239,10 @@ describe("Better PHPUnit Test Suite", function () {
         });
     });
 
-    it("Run entire suite with specified suites with Codeception", async () => {
+    it("Run entire suite with specified suffix with Codeception", async () => {
         await vscode.workspace.getConfiguration('better-phpunit').update('useCodeception', true);
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', path.join(vscode.workspace.rootPath, '/vendor/bin/codecept'));
-        await vscode.workspace.getConfiguration('better-phpunit').update('runSuites', 'unit, integration');
+        await vscode.workspace.getConfiguration('better-phpunit').update('runSuiteSuffix', 'unit --coverage');
         let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
         await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
         await vscode.commands.executeCommand('better-phpunit.run-suite')
@@ -250,7 +250,7 @@ describe("Better PHPUnit Test Suite", function () {
         await timeout(waitToAssertInSeconds, () => {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
-                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept run') + ' unit,integration'
+                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept run') + ' unit --coverage'
             );
         });
     });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -20,6 +20,7 @@ describe("Better PHPUnit Test Suite", function () {
         // This allows us to test config options in tests and not harm other tests.
         await vscode.workspace.getConfiguration('better-phpunit').update('commandSuffix', null);
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("useCodeception", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
@@ -31,6 +32,7 @@ describe("Better PHPUnit Test Suite", function () {
         // This allows us to test config options in tests and not harm other tests.
         await vscode.workspace.getConfiguration('better-phpunit').update('commandSuffix', null);
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("useCodeception", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
@@ -138,6 +140,20 @@ describe("Better PHPUnit Test Suite", function () {
         });
     });
 
+    it("Do not detect configuration if using Codeception", async () => {
+        await vscode.workspace.getConfiguration('better-phpunit').update('useCodeception', true);
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'sub-directory', 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document);
+        await vscode.commands.executeCommand('better-phpunit.run');
+
+        await timeout(waitToAssertInSeconds, () => {
+            assert.equal(
+                extension.getGlobalCommandInstance().configuration,
+                ``
+            );
+        });
+    });
+
     it("Uses configuration found in path supplied in settings", async () => {
         await vscode.workspace.getConfiguration('better-phpunit').update('xmlConfigFilepath', '/var/log/phpunit.xml');
         let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'sub-directory', 'tests', 'SampleTest.php'));
@@ -165,7 +181,25 @@ describe("Better PHPUnit Test Suite", function () {
         });
     });
 
+    it("Check full command using Codeception", async () => {
+        await vscode.workspace.getConfiguration('better-phpunit').update('useCodeception', true);
+        await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', path.join(vscode.workspace.rootPath, '/vendor/bin/codecept'));
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run');
+
+        await timeout(waitToAssertInSeconds, () => {
+            assert.equal(
+                extension.getGlobalCommandInstance().output,
+                path.join(vscode.workspace.rootPath, '/vendor/bin/codecept ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + ":test_first"
+            );
+        });
+    });
+
     it("Run previous", async () => {
+        let prevDocument = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(prevDocument, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run');
         let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'OtherTest.php'));
         await vscode.window.showTextDocument(document, { selection: new vscode.Range(12, 0, 12, 0) });
         await vscode.commands.executeCommand('better-phpunit.run-previous');

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -22,6 +22,7 @@ describe("Better PHPUnit Test Suite", function () {
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
     });
 
@@ -32,6 +33,7 @@ describe("Better PHPUnit Test Suite", function () {
         await vscode.workspace.getConfiguration('better-phpunit').update('phpunitBinary', null);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
         await vscode.workspace.getConfiguration("better-phpunit").update("xmlConfigFilepath", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("runSuites", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
     });
 
@@ -185,6 +187,20 @@ describe("Better PHPUnit Test Suite", function () {
             assert.equal(
                 extension.getGlobalCommandInstance().output,
                 path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit')
+            );
+        });
+    });
+
+    it("Run entire suite with specified suites", async () => {
+        await vscode.workspace.getConfiguration('better-phpunit').update('runSuites', 'unit, integration');
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run-suite')
+
+        await timeout(waitToAssertInSeconds, () => {
+            assert.equal(
+                extension.getGlobalCommandInstance().output,
+                path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit') + ' --testsuite unit,integration'
             );
         });
     });

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -53,7 +53,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)$'"
+            path.join(vscode.workspace.rootPath, '/vendor/bin/phpunit ') + path.join(vscode.workspace.rootPath, '/tests/SampleTest.php') + " --filter '^.*::test_first( .*)?$'"
         );
     });
 
@@ -66,7 +66,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            'ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
         );
     });
 
@@ -81,7 +81,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            'putty -ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'putty -ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
         );
     });
 
@@ -96,7 +96,7 @@ describe("SSH Tests", function () {
 
         assert.equal(
             extension.getGlobalCommandInstance().output,
-            'ssh "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first$\'"'
+            'ssh "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
         );
     });
 });


### PR DESCRIPTION
Problem:
While PHPUnit is still very popular many projects now use Codeception (which includes PHPUnit). The syntax is slightly different for some options so out of the box it is not possible to run all better-phpunit commands with Codeception.

Solution:
Add a new option to specify that you want to use Codeception instead of PHPUnit. With the option "useCodeception" (which is false by default) the syntax is changed accordingly so that you are able to use Codeception (provided that you specified it's binary in the option "better-phpunit.phpunitBinary".

Remark:
This patch obviously had to include my previous one for fixing the extension tests.
Attention: For brevity I have also included my other patch (runSuites) in this one!
