### PR TITLE
Docker command changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,14 @@
                     "default": null,
                     "description": "Absolute path for the PHPUnit XML configuration file"
                 },
+				"better-phpunit.xmlConfigFileName": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "PHPUnit XML configuration file name"
+				},
                 "better-phpunit.ssh.enable": {
                     "type": "boolean",
                     "default": false,

--- a/src/docker-phpunit-command.js
+++ b/src/docker-phpunit-command.js
@@ -6,6 +6,27 @@ module.exports = class DockerPhpUnitCommand extends RemotePhpUnitCommand {
         return this.config.get("docker.paths");
     }
 
+    get remotePath() {
+        for (const [localPath, remotePath] of Object.entries(this.paths)) {
+            if (!remotePath.endsWith('/')) {
+                return remotePath + '/';
+            }
+            return remotePath;
+        }
+    }
+
+    get xmlConfigFileName() {
+        if (this.config.get("xmlConfigFileName")) {
+            return this.config.get("xmlConfigFileName");
+        } 
+
+        return 'phpunit.xml';
+    }
+
+    get configuration() {
+        return ' --configuration ' + this._normalizePath(this.remotePath) + `${this.xmlConfigFileName}`;
+    }
+
     get dockerCommand() {
         if (this.config.get("docker.command")) {
             return this.config.get("docker.command");
@@ -18,6 +39,13 @@ module.exports = class DockerPhpUnitCommand extends RemotePhpUnitCommand {
     }
 
     wrapCommand(command) {
-        return `${this.dockerCommand} ${command}`;
+        var runCommand = `${this.dockerCommand}`;
+        runCommand += `${this.configuration}`;
+        runCommand += ' ' + `${this.file}`;
+        if (this.filter) {
+            runCommand += ' ' + `${this.filter}`;
+        }
+
+        return runCommand;
     }
 } 


### PR DESCRIPTION
- Changes on the docker command, so that it uses the phpunit installed in a docker and not always use the phpunit under vendor folder.
- Added xmlConfigFileName parameter, so that the user can set a totally different one. If this is not set defaults to phpunit.xml