### PR TITLE
Use docker via ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Running tests with Docker Compose, starting up a service and removing the contai
 }
 ```
 
+**Note:**
+For running Docker over a SSH session just use both options _ssh.enable_ and _docker.enable_ combined.
+
 ## Wish List:
 - Handling PHP fatal and parser errors
 - A sidebar panel for managing errors

--- a/src/docker-phpunit-command.js
+++ b/src/docker-phpunit-command.js
@@ -18,6 +18,9 @@ module.exports = class DockerPhpUnitCommand extends RemotePhpUnitCommand {
     }
 
     wrapCommand(command) {
+        if (vscode.workspace.getConfiguration("better-phpunit").get("ssh.enable")) {
+            return super.wrapCommand(`${this.dockerCommand} ${command}`);
+        }
         return `${this.dockerCommand} ${command}`;
     }
 } 

--- a/src/extension.js
+++ b/src/extension.js
@@ -24,10 +24,10 @@ module.exports.activate = function (context) {
     }));
 
     disposables.push(vscode.commands.registerCommand('better-phpunit.run-suite', async () => {
-        if (vscode.workspace.getConfiguration("better-phpunit").get("ssh.enable")) {
-            command = new RemotePhpUnitCommand({ runFullSuite: true });
-        } else if (vscode.workspace.getConfiguration("better-phpunit").get("docker.enable")) {
+        if (vscode.workspace.getConfiguration("better-phpunit").get("docker.enable")) {
             command = new DockerPhpUnitCommand({ runFullSuite: true });
+        } else if (vscode.workspace.getConfiguration("better-phpunit").get("ssh.enable")) {
+            command = new RemotePhpUnitCommand({ runFullSuite: true });
         } else {
             command = new PhpUnitCommand({ runFullSuite: true });
         }

--- a/src/extension.js
+++ b/src/extension.js
@@ -12,10 +12,10 @@ module.exports.activate = function (context) {
     disposables.push(vscode.commands.registerCommand('better-phpunit.run', async () => {
         let command;
 
-        if (vscode.workspace.getConfiguration("better-phpunit").get("ssh.enable")) {
-            command = new RemotePhpUnitCommand;
-        } else if (vscode.workspace.getConfiguration("better-phpunit").get("docker.enable")) {
+        if (vscode.workspace.getConfiguration("better-phpunit").get("docker.enable")) {
             command = new DockerPhpUnitCommand;
+        } else if (vscode.workspace.getConfiguration("better-phpunit").get("ssh.enable")) {
+            command = new RemotePhpUnitCommand;
         } else {
             command = new PhpUnitCommand;
         }

--- a/src/extension.js
+++ b/src/extension.js
@@ -24,6 +24,8 @@ module.exports.activate = function (context) {
     }));
 
     disposables.push(vscode.commands.registerCommand('better-phpunit.run-suite', async () => {
+        let command;
+
         if (vscode.workspace.getConfiguration("better-phpunit").get("docker.enable")) {
             command = new DockerPhpUnitCommand({ runFullSuite: true });
         } else if (vscode.workspace.getConfiguration("better-phpunit").get("ssh.enable")) {

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -94,6 +94,26 @@ describe("SSH Tests", function () {
         );
     });
 
+    it("The correct Docker suite command is run when triggering Better PHPUnit", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", true);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.command", "docker exec CONTAINER");
+        const paths = {};
+        paths[path.join(vscode.workspace.rootPath)] = "/some/remote/path";
+        paths["/some/other_local/path"] = "/some/other_remote/path";
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.paths", paths);
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run-suite');
+
+        await timeout(waitToAssertInSeconds, () => { })
+
+        assert.equal(
+            extension.getGlobalCommandInstance().output,
+            'docker exec CONTAINER /some/remote/path/vendor/bin/phpunit'
+        );
+    });
+
     it("The correct Docker command is run via SSH when triggering Better PHPUnit", async function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", true);
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.command", "docker exec CONTAINER");
@@ -110,6 +130,25 @@ describe("SSH Tests", function () {
         assert.equal(
             extension.getGlobalCommandInstance().output,
             'ssh -tt -p2222 auser@ahost "docker exec CONTAINER /some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
+        );
+    });
+
+    it("The correct Docker suite command is run via SSH when triggering Better PHPUnit", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", true);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.command", "docker exec CONTAINER");
+        const paths = {};
+        paths[path.join(vscode.workspace.rootPath)] = "/some/remote/path";
+        paths["/some/other_local/path"] = "/some/other_remote/path";
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.paths", paths);
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run-suite');
+
+        await timeout(waitToAssertInSeconds, () => { })
+
+        assert.equal(
+            extension.getGlobalCommandInstance().output,
+            'ssh -tt -p2222 auser@ahost "docker exec CONTAINER /some/remote/path/vendor/bin/phpunit"'
         );
     });
 

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -24,6 +24,8 @@ describe("SSH Tests", function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.host", "ahost");
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.port", "2222");
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.command", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.paths", null);
 
         const paths = {};
         paths[path.join(vscode.workspace.rootPath)] = "/some/remote/path";
@@ -40,6 +42,8 @@ describe("SSH Tests", function () {
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.binary", null);
         await vscode.workspace.getConfiguration("better-phpunit").update("ssh.paths", {});
         await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", false);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.command", null);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.paths", null);
     });
 
     it("Commands are not wrapped when SSH is disabled", async function () {
@@ -67,6 +71,45 @@ describe("SSH Tests", function () {
         assert.equal(
             extension.getGlobalCommandInstance().output,
             'ssh -tt -p2222 auser@ahost "/some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
+        );
+    });
+
+    it("The correct Docker command is run when triggering Better PHPUnit", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("ssh.enable", false);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", true);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.command", "docker exec CONTAINER");
+        const paths = {};
+        paths[path.join(vscode.workspace.rootPath)] = "/some/remote/path";
+        paths["/some/other_local/path"] = "/some/other_remote/path";
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.paths", paths);
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run');
+
+        await timeout(waitToAssertInSeconds, () => { })
+
+        assert.equal(
+            extension.getGlobalCommandInstance().output,
+            'docker exec CONTAINER /some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\''
+        );
+    });
+
+    it("The correct Docker command is run via SSH when triggering Better PHPUnit", async function () {
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.enable", true);
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.command", "docker exec CONTAINER");
+        const paths = {};
+        paths[path.join(vscode.workspace.rootPath)] = "/some/remote/path";
+        paths["/some/other_local/path"] = "/some/other_remote/path";
+        await vscode.workspace.getConfiguration("better-phpunit").update("docker.paths", paths);
+        let document = await vscode.workspace.openTextDocument(path.join(vscode.workspace.rootPath, 'tests', 'SampleTest.php'));
+        await vscode.window.showTextDocument(document, { selection: new vscode.Range(7, 0, 7, 0) });
+        await vscode.commands.executeCommand('better-phpunit.run');
+
+        await timeout(waitToAssertInSeconds, () => { })
+
+        assert.equal(
+            extension.getGlobalCommandInstance().output,
+            'ssh -tt -p2222 auser@ahost "docker exec CONTAINER /some/remote/path/vendor/bin/phpunit /some/remote/path/tests/SampleTest.php --filter \'^.*::test_first( .*)?$\'"'
         );
     });
 


### PR DESCRIPTION
Problem:
Currently you are not able(¹) to run Docker over a SSH connection within the extension albeit the DockerPhpUnitCommand inherits from RemotePhpUnitCommand. My use case is that I have a Vagrant Virtualbox running CoreOS which runs the Docker containers (WordPress) in which I want to run my test cases.

Solution:
Just a small change in the order of checks for which command is to be instantiated as "command" and a call to super.wrapCommand if Docker and SSH are both enabled.

Footnote:
¹ It is not totally true, you can force the extension to run Docker over SSH by putting "docker exec CONTAINER" infront of your better-phpunit.phpunitBinary option - but this is rather clumsy. ;-)