### PR TITLE
Generate HTML or Text coverage for the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-phpunit",
-    "version": "1.3.3",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "better-phpunit",
     "displayName": "Better PHPUnit",
     "description": "A better PHPUnit test runner",
-    "version": "1.3.3",
+    "version": "1.4.0",
     "publisher": "calebporzio",
     "engines": {
         "vscode": "^1.17.0"

--- a/package.json
+++ b/package.json
@@ -98,15 +98,15 @@
                     "default": null,
                     "description": "Relative path for the generated coverage files, based on the project folder. Ex: 'test/coverage'"
                 },
-				"better-phpunit.coverageFormat": {
-					"type": "string",
-					"enum": [
-						"Text",
-						"HTML"
-					],
-					"default": "Text",
-					"description": "Select the coverage report format"
-				},
+                "better-phpunit.coverageFormat": {
+                    "type": "string",
+                    "enum": [
+                        "Text",
+                        "HTML"
+                    ],
+                    "default": "Text",
+                    "description": "Select the coverage report format"
+                },
                 "better-phpunit.ssh.enable": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -18,10 +18,8 @@
     "activationEvents": [
         "onCommand:better-phpunit.run",
         "onCommand:better-phpunit.run-suite",
-        "onCommand:better-phpunit.coverage-text",
-        "onCommand:better-phpunit.coverage-html",
-        "onCommand:better-phpunit.coverage-suite-text",
-        "onCommand:better-phpunit.coverage-suite-html"
+        "onCommand:better-phpunit.coverage",
+        "onCommand:better-phpunit.coverage-suite"
     ],
     "main": "./src/extension",
     "contributes": {
@@ -39,20 +37,12 @@
                 "title": "Better PHPUnit: run previous"
             },
             {
-                "command": "better-phpunit.coverage-text",
-                "title": "Better PHPUnit: run with text coverage"
+                "command": "better-phpunit.coverage",
+                "title": "Better PHPUnit: run with coverage"
             },
             {
-                "command": "better-phpunit.coverage-html",
-                "title": "Better PHPUnit: run with html coverage"
-            },
-            {
-                "command": "better-phpunit.coverage-suite-text",
-                "title": "Better PHPUnit: run suite with text coverage"
-            },
-            {
-                "command": "better-phpunit.coverage-suite-html",
-                "title": "Better PHPUnit: run suite with html coverage"
+                "command": "better-phpunit.coverage-suite",
+                "title": "Better PHPUnit: run suite with coverage"
             }
         ],
         "keybindings": [
@@ -108,6 +98,15 @@
                     "default": null,
                     "description": "Relative path for the generated coverage files, based on the project folder. Ex: 'test/coverage'"
                 },
+				"better-phpunit.coverageFormat": {
+					"type": "string",
+					"enum": [
+						"Text",
+						"HTML"
+					],
+					"default": "Text",
+					"description": "Select the coverage report format"
+				},
                 "better-phpunit.ssh.enable": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -1,244 +1,254 @@
 {
-    "name": "better-phpunit",
-    "displayName": "Better PHPUnit",
-    "description": "A better PHPUnit test runner",
-    "version": "1.5.1",
-    "publisher": "calebporzio",
-    "engines": {
-        "vscode": "^1.17.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/calebporzio/better-phpunit.git"
-    },
-    "icon": "icon.png",
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onCommand:better-phpunit.run",
-        "onCommand:better-phpunit.run-file",
-        "onCommand:better-phpunit.run-suite",
-        "onCommand:better-phpunit.coverage",
-        "onCommand:better-phpunit.coverage-suite"
-    ],
-    "main": "./src/extension",
-    "contributes": {
-        "commands": [
-            {
-                "command": "better-phpunit.run",
-                "title": "Better PHPUnit: run"
-            },
-            {
-                "command": "better-phpunit.run-file",
-                "title": "Better PHPUnit: run file"
-            },
-            {
-                "command": "better-phpunit.run-suite",
-                "title": "Better PHPUnit: run suite"
-            },
-            {
-                "command": "better-phpunit.run-previous",
-                "title": "Better PHPUnit: run previous"
-            },
-            {
-                "command": "better-phpunit.coverage",
-                "title": "Better PHPUnit: run with coverage"
-            },
-            {
-                "command": "better-phpunit.coverage-suite",
-                "title": "Better PHPUnit: run suite with coverage"
-            }
-        ],
-        "keybindings": [
-            {
-                "key": "cmd+k cmd+r",
-                "command": "better-phpunit.run"
-            },
-            {
-                "key": "cmd+k cmd+f",
-                "command": "better-phpunit.run-file"
-            },
-            {
-                "key": "cmd+k cmd+p",
-                "command": "better-phpunit.run-previous"
-            }
-        ],
-        "configuration": {
-            "title": "Better PHPUnit configuration",
-            "properties": {
-                "better-phpunit.commandSuffix": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "This string will be appended to the phpunit command, it's a great place to add flags like '--stop-on-failure'"
-                },
-                "better-phpunit.phpunitBinary": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'"
-                },
-                "better-phpunit.xmlConfigFilepath": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Absolute path for the PHPUnit XML configuration file"
-                },
-                "better-phpunit.suiteSuffix": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Specify options to appended only to the 'run suite' command, for example add options like '--testsuite unit' or '--coverage  --coverage-xml'"
-                },
-                "better-phpunit.coveragePath": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Relative path for the generated coverage files, based on the project folder. Ex: 'test/coverage'"
-                },
-                "better-phpunit.coverageFormat": {
-                    "type": "string",
-                    "enum": [
-                        "Text",
-                        "HTML"
-                    ],
-                    "default": "Text",
-                    "description": "Select the coverage report format"
-                },
-                "better-phpunit.ssh.enable": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Run tests over SSH"
-                },
-                "better-phpunit.ssh.user": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "The user to connect as when running test via SSH"
-                },
-                "better-phpunit.ssh.host": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "The hostname to use when running tests via SSH"
-                },
-                "better-phpunit.ssh.port": {
-                    "type": [
-                        "integer"
-                    ],
-                    "default": 22,
-                    "description": "The port to use when running tests via SSH.  Deprecated, set better-phpunit.options to '-p[port]' on Linux/Mac, and '-P [port]' on Windows."
-                },
-                "better-phpunit.ssh.paths": {
-                    "type": "object",
-                    "default": {},
-                    "description": "The SSH path map. Keys are local (host) paths and values are remote (guest) paths."
-                },
-                "better-phpunit.ssh.binary": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "The path (and flags) to an SSH-compatible binary. If null it will use SSH on *nix and Putty on Windows."
-                },
-                "better-phpunit.ssh.disableAllOptions": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Do not include any config options in SSH command."
-                },
-                "better-phpunit.ssh.options": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Additional command line options to pass to ssh/putty/plink"
-                },
-                "better-phpunit.docker.enable": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Run tests within a Docker container"
-                },
-                "better-phpunit.docker.command": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "The Docker command to execute a container. If null, an error will be thrown during execution."
-                },
-                "better-phpunit.docker.paths": {
-                    "type": "object",
-                    "default": {},
-                    "description": "The docker path map. Keys are local (host) paths and values are remote (container) paths."
-                }
-            }
-        },
-        "problemMatchers": [
-            {
-                "name": "phpunit",
-                "owner": "php",
-                "fileLocation": "absolute",
-                "pattern": [
-                    {
-                        "regexp": "^\\d+\\)\\s.*$"
-                    },
-                    {
-                        "regexp": "^(.*)$",
-                        "message": 1
-                    },
-                    {
-                        "regexp": "^(.*):(\\d+)$",
-                        "file": 1,
-                        "location": 2
-                    }
-                ]
-            }
-        ],
-        "taskDefinitions": [
-            {
-                "type": "phpunit",
-                "required": [
-                    "task"
-                ],
-                "properties": {
-                    "task": {
-                        "type": "string",
-                        "description": "The task to execute"
-                    }
-                }
-            }
-        ]
-    },
-    "scripts": {
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.42",
-        "@types/node": "^7.10.2",
-        "eslint": "^4.6.1",
-        "mocha": "^4.1.0",
-        "typescript": "^2.5.2",
-        "vscode": "^1.1.22"
-    },
-    "dependencies": {
-        "find-up": "^2.1.0"
-    }
+	"name": "better-phpunit",
+	"displayName": "Better PHPUnit",
+	"description": "A better PHPUnit test runner",
+	"version": "1.5.1",
+	"publisher": "calebporzio",
+	"engines": {
+		"vscode": "^1.17.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/calebporzio/better-phpunit.git"
+	},
+	"icon": "icon.png",
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"onCommand:better-phpunit.run",
+		"onCommand:better-phpunit.run-file",
+		"onCommand:better-phpunit.run-suite",
+		"onCommand:better-phpunit.coverage",
+		"onCommand:better-phpunit.coverage-file",
+		"onCommand:better-phpunit.coverage-suite"
+	],
+	"main": "./src/extension",
+	"contributes": {
+		"commands": [
+			{
+				"command": "better-phpunit.run",
+				"title": "Better PHPUnit: run"
+			},
+			{
+				"command": "better-phpunit.run-file",
+				"title": "Better PHPUnit: run file"
+			},
+			{
+				"command": "better-phpunit.run-suite",
+				"title": "Better PHPUnit: run suite"
+			},
+			{
+				"command": "better-phpunit.run-previous",
+				"title": "Better PHPUnit: run previous"
+			},
+			{
+				"command": "better-phpunit.coverage",
+				"title": "Better PHPUnit: run with coverage"
+			},
+			{
+				"command": "better-phpunit.coverage-file",
+				"title": "Better PHPUnit: run file with coverage"
+			},
+			{
+				"command": "better-phpunit.coverage-suite",
+				"title": "Better PHPUnit: run suite with coverage"
+			}
+		],
+		"keybindings": [
+			{
+				"key": "cmd+k cmd+r",
+				"command": "better-phpunit.run"
+			},
+			{
+				"key": "cmd+k cmd+f",
+				"command": "better-phpunit.run-file"
+			},
+			{
+				"key": "cmd+k cmd+p",
+				"command": "better-phpunit.run-previous"
+			}
+		],
+		"configuration": {
+			"title": "Better PHPUnit configuration",
+			"properties": {
+				"better-phpunit.commandSuffix": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "This string will be appended to the phpunit command, it's a great place to add flags like '--stop-on-failure'"
+				},
+				"better-phpunit.phpunitBinary": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "A custom phpunit binary. Ex: 'phpunit', '/usr/local/bin/phpunit'"
+				},
+				"better-phpunit.xmlConfigFilepath": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Absolute path for the PHPUnit XML configuration file"
+				},
+				"better-phpunit.suiteSuffix": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Specify options to appended only to the 'run suite' command, for example add options like '--testsuite unit' or '--coverage  --coverage-xml'"
+				},
+				"better-phpunit.coveragePath": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Relative path for the generated coverage files, based on the project folder. Ex: 'test/coverage'"
+				},
+				"better-phpunit.coverageFormat": {
+					"type": "string",
+					"enum": [
+						"Text",
+						"HTML"
+					],
+					"default": "Text",
+					"description": "Select the coverage report format"
+				},
+				"better-phpunit.ssh.enable": {
+					"type": "boolean",
+					"default": false,
+					"description": "Run tests over SSH"
+				},
+				"better-phpunit.ssh.user": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "The user to connect as when running test via SSH"
+				},
+				"better-phpunit.ssh.host": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "The hostname to use when running tests via SSH"
+				},
+				"better-phpunit.ssh.port": {
+					"type": [
+						"integer"
+					],
+					"default": 22,
+					"description": "The port to use when running tests via SSH.  Deprecated, set better-phpunit.options to '-p[port]' on Linux/Mac, and '-P [port]' on Windows."
+				},
+				"better-phpunit.ssh.paths": {
+					"type": "object",
+					"default": {},
+					"description": "The SSH path map. Keys are local (host) paths and values are remote (guest) paths."
+				},
+				"better-phpunit.ssh.binary": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "The path (and flags) to an SSH-compatible binary. If null it will use SSH on *nix and Putty on Windows."
+				},
+				"better-phpunit.ssh.disableAllOptions": {
+					"type": "boolean",
+					"default": false,
+					"description": "Do not include any config options in SSH command."
+				},
+				"better-phpunit.ssh.options": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Additional command line options to pass to ssh/putty/plink"
+				},
+				"better-phpunit.docker.enable": {
+					"type": "boolean",
+					"default": false,
+					"description": "Run tests within a Docker container"
+				},
+				"better-phpunit.docker.command": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "The Docker command to execute a container. If null, an error will be thrown during execution."
+				},
+				"better-phpunit.docker.paths": {
+					"type": "object",
+					"default": {},
+					"description": "The docker path map. Keys are local (host) paths and values are remote (container) paths."
+				}
+			}
+		},
+		"problemMatchers": [
+			{
+				"name": "phpunit",
+				"owner": "php",
+				"fileLocation": "absolute",
+				"pattern": [
+					{
+						"regexp": "^\\d+\\)\\s.*$"
+					},
+					{
+						"regexp": "^(.*)$",
+						"message": 1
+					},
+					{
+						"regexp": "^(.*):(\\d+)$",
+						"file": 1,
+						"location": 2
+					}
+				]
+			}
+		],
+		"taskDefinitions": [
+			{
+				"type": "phpunit",
+				"required": [
+					"task"
+				],
+				"properties": {
+					"task": {
+						"type": "string",
+						"description": "The task to execute"
+					}
+				}
+			}
+		]
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install",
+		"test": "node ./node_modules/vscode/bin/test"
+	},
+	"devDependencies": {
+		"@types/mocha": "^2.2.42",
+		"@types/node": "^7.10.2",
+		"eslint": "^4.6.1",
+		"mocha": "^4.1.0",
+		"typescript": "^2.5.2",
+		"vscode": "^1.1.22"
+	},
+	"dependencies": {
+		"find-up": "^2.1.0"
+	},
+	"__metadata": {
+		"id": "2dd41a16-fc28-4680-a274-a850fa5f1098",
+		"publisherDisplayName": "calebporzio",
+		"publisherId": "a2487481-f6cb-4f67-9340-4db67a69d30d"
+	}
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -41,20 +41,12 @@ module.exports.activate = function (context) {
         await runPreviousCommand();
     }));
 
-    disposables.push(vscode.commands.registerCommand('better-phpunit.coverage-text', async () => {
-        await runWithCoverage({ coverageType: 'text' });
+    disposables.push(vscode.commands.registerCommand('better-phpunit.coverage', async () => {
+        await runWithCoverage({ coverageType: getCoverageFormat() });
     }));
 
-    disposables.push(vscode.commands.registerCommand('better-phpunit.coverage-html', async () => {
-        await runWithCoverage({ coverageType: 'html' });
-    }));
-
-    disposables.push(vscode.commands.registerCommand('better-phpunit.coverage-suite-text', async () => {
-        await runWithCoverage({ coverageType: 'text', runFullSuite: true });
-    }));
-
-    disposables.push(vscode.commands.registerCommand('better-phpunit.coverage-suite-html', async () => {
-        await runWithCoverage({ coverageType: 'html', runFullSuite: true });
+    disposables.push(vscode.commands.registerCommand('better-phpunit.coverage-suite', async () => {
+        await runWithCoverage({ coverageType: getCoverageFormat(), runFullSuite: true });
     }));
 
     disposables.push(vscode.tasks.registerTaskProvider('phpunit', {
@@ -105,6 +97,10 @@ async function runWithCoverage(options) {
     }
 
     await runCommand(command);
+}
+
+function getCoverageFormat() {
+    return vscode.workspace.getConfiguration('better-phpunit').get('coverageFormat').toLowerCase();
 }
 
 // This method is exposed for testing purposes.

--- a/src/extension.js
+++ b/src/extension.js
@@ -59,6 +59,10 @@ module.exports.activate = function (context) {
         await runWithCoverage({ coverageType: getCoverageFormat() });
     }));
 
+    disposables.push(vscode.commands.registerCommand('better-phpunit.coverage-file', async () => {
+        await runWithCoverage({ coverageType: getCoverageFormat(), runFile: true });
+    }));
+
     disposables.push(vscode.commands.registerCommand('better-phpunit.coverage-suite', async () => {
         await runWithCoverage({ coverageType: getCoverageFormat(), runFullSuite: true });
     }));

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -95,11 +95,8 @@ module.exports = class PhpUnitCommand {
     get coverage() {
         let coverage = '';
         let coveragePath = vscode.workspace.getConfiguration('better-phpunit').get('coveragePath');
-        if (coveragePath === null) {
-            coveragePath = '';
-        }
 
-        if (this.coverageType !== '') {
+        if (coveragePath) {
             switch (this.coverageType) {
                 case 'text': {
                     coverage += ` --coverage-text=${this._normalizePath(path.join(coveragePath, 'coverage.txt'))}`;
@@ -111,7 +108,7 @@ module.exports = class PhpUnitCommand {
                 }
             }
         } else {
-            // TODO: Put some error message here
+            vscode.window.showErrorMessage("The coverage path is not set at the configuration. No coverage report will be generated.");
         }
 
         return coverage ? ' ' + coverage : '';

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -24,8 +24,8 @@ module.exports = class PhpUnitCommand {
         suiteSuffix = suiteSuffix ? ' '.concat(suiteSuffix) : '';
 
         this.lastOutput = this.runFullSuite
-            ? `${this.binary}${suiteSuffix}${this.suffix}${this.coverage}`
-            : `${this.binary} ${this.file}${this.filter}${this.configuration}${this.suffix}${this.coverage}`;
+            ? `${this.binary}${suiteSuffix}${this.coverage}${this.suffix}`
+            : `${this.binary} ${this.file}${this.filter}${this.configuration}${this.coverage}${this.suffix}`;
 
         return this.lastOutput;
     }

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -28,15 +28,13 @@ module.exports = class PhpUnitCommand {
         suiteSuffix = suiteSuffix ? ' '.concat(suiteSuffix) : '';
 
         if (this.runFullSuite) {
-            this.lastOutput = `${this.binary}${suiteSuffix}${this.suffix}`
+            this.lastOutput = `${this.binary}${suiteSuffix}${this.coverage}${this.suffix}`
         } else if (this.runFile) {
-            this.lastOutput = `${this.binary} ${this.file}${this.configuration}${this.suffix}`;
-        } else if (this.coverageType) {
-            this.lastOutput = `${this.binary} ${this.file}${this.filter}${this.configuration}${this.coverage}${this.suffix}`;
+            this.lastOutput = `${this.binary} ${this.file}${this.configuration}${this.coverage}${this.suffix}`;
         } else {
-            this.lastOutput = `${this.binary} ${this.file}${this.filter}${this.configuration}${this.suffix}`;
+            this.lastOutput = `${this.binary} ${this.file}${this.filter}${this.configuration}${this.coverage}${this.suffix}`;
         }
-
+        
         return this.lastOutput;
     }
 
@@ -115,11 +113,11 @@ module.exports = class PhpUnitCommand {
         if (coveragePath) {
             switch (this.coverageType) {
                 case 'text': {
-                    coverage += ` --coverage-text=${this._normalizePath(path.join(coveragePath, 'coverage.txt'))}`;
+                    coverage += ` --coverage-text=${this._normalizePath(path.join(coveragePath, 'coverage.txt'))} `;
                     break;
                 }
                 case 'html': {
-                    coverage += ` --coverage-html ${this._normalizePath(coveragePath)}`;
+                    coverage += ` --coverage-html ${this._normalizePath(coveragePath)} `;
                     break;
                 }
             }


### PR DESCRIPTION
This Pull Request is based on the PHPUnit coverage as I introduced it at #94 , but now it is for the latest version of Better-PHPUnit.

- Added a new configuration variable, where the user can select the format of the Coverage report, which by default is text.
- Reduced the commands to two than four, so that it is easier for the users
- Added an Error Message for the user in case the coverage path is not set when the user runs a test with coverage. The test is not prevented from running.

hope this implementation will be useful for others too.