### PR TITLE
#103 php unit will not run the test on windows pc

### DIFF
--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -40,7 +40,7 @@ module.exports = class PhpUnitCommand {
 
     get filter() {
         return process.platform === "win32"
-            ? (this.method ? ` --filter '^.*::${this.method}$'` : '')
+            ? (this.method ? ` --filter '^.*::${this.method}'` : '')
             : (this.method ? ` --filter '^.*::${this.method}( .*)?$'` : '');
     }
 

--- a/src/phpunit-command.js
+++ b/src/phpunit-command.js
@@ -59,6 +59,12 @@ module.exports = class PhpUnitCommand {
 
         return suffix ? ' ' + suffix : ''; // Add a space before the suffix.
     }
+	
+	get windowsSuffix() {
+        return process.platform === "win32"
+            ? '.bat'
+            : '';
+    }
 
     get binary() {
         if (vscode.workspace.getConfiguration('better-phpunit').get('phpunitBinary')) {
@@ -66,8 +72,8 @@ module.exports = class PhpUnitCommand {
         }
 
         return this.subDirectory
-            ? this._normalizePath(path.join(this.subDirectory, 'vendor', 'bin', 'phpunit'))
-            : this._normalizePath(path.join(vscode.workspace.rootPath, 'vendor', 'bin', 'phpunit'));
+            ? this._normalizePath(path.join(this.subDirectory, 'vendor', 'bin', 'phpunit'+this.windowsSuffix))
+            : this._normalizePath(path.join(vscode.workspace.rootPath, 'vendor', 'bin', 'phpunit'+this.windowsSuffix));
     }
 
     get subDirectory() {


### PR DESCRIPTION
As per #103 I've added a windowsSuffix method and amended the command line so on a windows PC PHPUNit.bat is called.

This also includes #102 for removing the $ from the filter.

I hope this is acceptable. Any problems let me know. This is possibly a fix for #47  too, except my command window didn't stay open though.