### PR TITLE
Replaces ${workspaceFolder} in local path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-phpunit",
-    "version": "1.4.0",
+    "version": "1.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/remote-phpunit-command.js
+++ b/src/remote-phpunit-command.js
@@ -42,7 +42,9 @@ module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
 
     remapLocalPath(actualPath) {
         for (const [localPath, remotePath] of Object.entries(this.paths)) {
-            const expandedLocalPath = localPath.replace(/^~/, os.homedir());
+            const expandedLocalPath = localPath
+                .replace(/^~/, os.homedir())
+                .replace(/\$\{workspaceFolder\}/g, vscode.workspace.rootPath);
             if (actualPath.startsWith(expandedLocalPath)) {
                 return actualPath.replace(expandedLocalPath, remotePath);
             }


### PR DESCRIPTION
This makes it possible to have this in your vscode workspace config file:

```json
{
    "better-phpunit.docker.enable": true,
    "better-phpunit.docker.command": "docker-compose exec php",
    "better-phpunit.docker.paths": {
        "${workspaceFolder}": "/var/www"
    }
}
```
 
Some notes:

- After running `npm install` it also fixed the out-of-sync lock file (it only updated the "version" key).
- I have (manually) tested it by compiling a vscode package (.vsix) and loading that up.
- Never done anything with extensions so had to read up on the subject (seems fun :) will definitely come back and create my own vscode extension)
- It show some deprecation warning for `vscode.workspace.rootPath`. Related to multi workspace environment support. See https://github.com/microsoft/vscode/wiki/Adopting-Multi-Root-Workspace-APIs#eliminating-rootpath
- Have not add tests for this specific feature. Docker support also does not seem to be tested although it seems to be based largely on the ssh support.
- Related to https://github.com/calebporzio/better-phpunit/issues/108