### PR TITLE
Replace ${workspaceFolder} in local path

### DIFF
--- a/src/remote-phpunit-command.js
+++ b/src/remote-phpunit-command.js
@@ -42,7 +42,12 @@ module.exports = class RemotePhpUnitCommand extends PhpUnitCommand {
 
     remapLocalPath(actualPath) {
         for (const [localPath, remotePath] of Object.entries(this.paths)) {
-            const expandedLocalPath = localPath.replace(/^~/, os.homedir());
+            const currentOpenFilePath = vscode.window.activeTextEditor.document.uri;
+            const currentWorkspacePath = vscode.workspace.getWorkspaceFolder(currentOpenFilePath)?.uri.fsPath;
+            const expandedLocalPath = localPath
+                .replace(/^~/, os.homedir())
+                .replace(/\$\{workspaceFolder\}/g, currentWorkspacePath);
+
             if (actualPath.startsWith(expandedLocalPath)) {
                 return actualPath.replace(expandedLocalPath, remotePath);
             }


### PR DESCRIPTION
This is a follow-up on @Ilyes512 [original PR](https://github.com/calebporzio/better-phpunit/pull/111).

The original solution has been deprecated in VSCode's extension API, now we're fetching the workspace folder URI based on which file is currently active in the editor, so it works for multi-root workspaces. This allows one to use the `${workspaceFolder}` variable in the local path when configuring docker paths:

```json
{
    "better-phpunit.docker.enable": true,
    "better-phpunit.docker.command": "docker-compose exec php",
    "better-phpunit.docker.paths": {
        "${workspaceFolder}": "/var/www"
    }
}
```

This is my first time working on VSCode extension and I had a hard time getting the development environment working for this project, so I just replaced the code in-place on my currently installed version of the extension. If there is anything I've missed in expected procedures, please do let me know and I'll make changes accordingly.

I'd be very grateful for this getting merged since it would allow our team to ship a default configuration that works without additional configuration for our developers.