### PR TITLE
Return immediately when globalCommand is undefined

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -56,6 +56,9 @@ module.exports.activate = function (context) {
 
     disposables.push(vscode.tasks.registerTaskProvider('phpunit', {
         provideTasks: () => {
+
+            if (!globalCommand) return [];
+
             return [new vscode.Task(
                 { type: "phpunit", task: "run" },
                 2,


### PR DESCRIPTION
The extension currently affects task detection when user tries to run tasks.

When globalCommand is undefined, the task discovery times out with the message:
`Timed out getting tasks from  phpunit`.

This significantly affects the time VS Code takes to discover tasks.

![issue](https://github.com/user-attachments/assets/45497cba-c02d-4cd5-b10b-8fb9f4b9eb7b)
![fix](https://github.com/user-attachments/assets/0ac1a37c-c1c1-4ee8-851f-bd8a1816b160)
